### PR TITLE
Fix for issue IDGEN-27

### DIFF
--- a/omod/src/main/webapp/editIdentifierSource.jsp
+++ b/omod/src/main/webapp/editIdentifierSource.jsp
@@ -13,7 +13,7 @@
 <h3>
 	<c:choose>
 		<c:when test="${empty source.id}">
-			<spring:message code="general.new" />: <spring:message code="idgen.${source.class.name}" />
+			<spring:message code="general.new" />: <spring:message code="idgen.${source['class'].name}" />
 		</c:when>
 		<c:otherwise>
 			<spring:message code="general.edit" />: ${source.name}
@@ -63,7 +63,7 @@
 			</td>
 		</tr>		
 		
-		<c:if test="${source.class.name == 'org.openmrs.module.idgen.SequentialIdentifierGenerator'}">
+		<c:if test="${source['class'].name == 'org.openmrs.module.idgen.SequentialIdentifierGenerator'}">
 			<tr>
 				<th align="right">
 					<span class="requiredField">*</span>
@@ -102,7 +102,7 @@
 				<td><frm:input path="length" size="10" /><frm:errors path="length" cssClass="error" /></td>
 			</tr>
 		</c:if>
-		<c:if test="${source.class.name == 'org.openmrs.module.idgen.RemoteIdentifierSource'}">
+		<c:if test="${source['class'].name == 'org.openmrs.module.idgen.RemoteIdentifierSource'}">
 			<tr>
 				<th align="right">
 					<span class="requiredField">*</span>
@@ -121,7 +121,7 @@
                 <td><frm:password path="password" size="20" /><frm:errors path="password" cssClass="error" /></td>
             </tr>
 		</c:if>
-		<c:if test="${source.class.name == 'org.openmrs.module.idgen.IdentifierPool'}">
+		<c:if test="${source['class'].name == 'org.openmrs.module.idgen.IdentifierPool'}">
 			<tr>
 				<th align="right"><spring:message code="idgen.poolSource" />:</th>
 				<td>

--- a/omod/src/main/webapp/manageIdentifierSources.jsp
+++ b/omod/src/main/webapp/manageIdentifierSources.jsp
@@ -34,7 +34,7 @@
 						<tr class="${entryStatus.index % 2 == 0 ? 'evenRow' : 'oddRow'} ${status.last ? 'underlineRow' : '' }">
 						
 							<td>${entry.key.name}</td>
-							<td><spring:message code="idgen.${source.class.name}"/></td>
+							<td><spring:message code="idgen.${source['class'].name}"/></td>
 							<td>${source.name}</td>
 							<td>
 								<button style="height:20px; font-size:8pt; vertical-align:middle;" onclick="document.location.href='editIdentifierSource.form?source=${source.id}';">

--- a/omod/src/main/webapp/viewIdentifierSource.jsp
+++ b/omod/src/main/webapp/viewIdentifierSource.jsp
@@ -45,7 +45,7 @@
 </table>
 <br/>
 
-<c:if test="${source.class.name == 'org.openmrs.module.idgen.SequentialIdentifierGenerator'}">
+<c:if test="${source['class'].name == 'org.openmrs.module.idgen.SequentialIdentifierGenerator'}">
 
 	This Identifier Source generates sequential identifiers with the following configuration:<br/><br/>
 	
@@ -87,12 +87,12 @@
 	</table>
 </c:if>
 
-<c:if test="${source.class.name == 'org.openmrs.module.idgen.RemoteIdentifierSource'}">
+<c:if test="${source['class'].name == 'org.openmrs.module.idgen.RemoteIdentifierSource'}">
 	This Identifier Source connects to the following remote URL to retrieve new identifiers:<br/>
 	${source.url}
 </c:if>
 
-<c:if test="${source.class.name == 'org.openmrs.module.idgen.IdentifierPool'}">
+<c:if test="${source['class'].name == 'org.openmrs.module.idgen.IdentifierPool'}">
 
 	This Identifier Source manages a pool of pre-generated identifiers.<br/><br/>
 	
@@ -125,7 +125,7 @@
 <form action="exportIdentifiers.form">
 	<b>Export Identifiers: </b>
 	<c:set var="available" value="t"/>
-	<c:if test="${source.class.name == 'org.openmrs.module.idgen.IdentifierPool'}">
+	<c:if test="${source['class'].name == 'org.openmrs.module.idgen.IdentifierPool'}">
 		<c:if test="${fn:length(source.availableIdentifiers) == 0}">
 			<c:set var="available" value="f"/>
 			None available for export.


### PR DESCRIPTION
Hi, 

This fixes errors with stack trace like http://pastebin.com/SAF1bRQC that appears when using IDGEN on Tomcat 7+. It is just a simple replace of all .class in the jsp files to ['class']. 

I have tested this on my local installation. The fix is the same as what I found on openmrs-core for issue 3109. 

Thanks
Vinay
