### PR TITLE
fixes IDGEN-18 https://issues.openmrs.org/browse/IDGEN-38

### DIFF
--- a/omod/src/main/java/org/openmrs/module/idgen/web/extension/IdentifierTableHeaderExtension.java
+++ b/omod/src/main/java/org/openmrs/module/idgen/web/extension/IdentifierTableHeaderExtension.java
@@ -24,6 +24,7 @@ import org.openmrs.module.idgen.service.IdentifierSourceService;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.web.WebConstants;
 import org.springframework.util.StringUtils;
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 
 /**
  * Provides additional Header Columns to the edit identifier table
@@ -54,7 +55,10 @@ public class IdentifierTableHeaderExtension extends Extension {
  		}
 
  		StringBuilder sb = new StringBuilder();
+		
+		
  		if (!autogen.isEmpty()) {
+ 	 		DefaultArtifactVersion openMRSversionShort = new DefaultArtifactVersion(OpenmrsConstants.OPENMRS_VERSION_SHORT);
  			
  			// solving IDGEN-11: when webapp_name is empty, double slashes cause wrong url
  			// in 1.10+, use WebUtil.getContextPath(); See TRUNK-
@@ -63,10 +67,10 @@ public class IdentifierTableHeaderExtension extends Extension {
  				contextPath += "/" + WebConstants.WEBAPP_NAME;
  			}
  			
- 	 		if (OpenmrsConstants.OPENMRS_VERSION_SHORT.compareTo("1.7") < 0) {
+ 	 		if (openMRSversionShort.compareTo(new DefaultArtifactVersion("1.7")) < 0) {
  	 			sb.append("<script src=\"" + contextPath + "/moduleResources/idgen/jquery-1.3.2.min.js\" type=\"text/javascript\"></script>\n");
  	 		}
- 	 		if (OpenmrsConstants.OPENMRS_VERSION_SHORT.compareTo("1.8") < 0) {
+ 	 		if (openMRSversionShort.compareTo(new DefaultArtifactVersion("1.8")) < 0) {
  	 			sb.append("<script src=\"" + contextPath + "/moduleResources/idgen/newPatientFormExtensions.js\" type=\"text/javascript\"></script>\n"); 		
  	 		}
  	 		else {

--- a/omod/src/main/java/org/openmrs/module/idgen/web/extension/IdentifierTableHeaderExtension.java
+++ b/omod/src/main/java/org/openmrs/module/idgen/web/extension/IdentifierTableHeaderExtension.java
@@ -19,12 +19,12 @@ import java.util.Map;
 import org.openmrs.PatientIdentifierType;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.Extension;
+import org.openmrs.module.ModuleUtil;
 import org.openmrs.module.idgen.AutoGenerationOption;
 import org.openmrs.module.idgen.service.IdentifierSourceService;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.web.WebConstants;
 import org.springframework.util.StringUtils;
-import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 
 /**
  * Provides additional Header Columns to the edit identifier table
@@ -56,10 +56,7 @@ public class IdentifierTableHeaderExtension extends Extension {
 
  		StringBuilder sb = new StringBuilder();
 		
-		
- 		if (!autogen.isEmpty()) {
- 	 		DefaultArtifactVersion openMRSversionShort = new DefaultArtifactVersion(OpenmrsConstants.OPENMRS_VERSION_SHORT);
- 			
+ 		if (!autogen.isEmpty()) { 			
  			// solving IDGEN-11: when webapp_name is empty, double slashes cause wrong url
  			// in 1.10+, use WebUtil.getContextPath(); See TRUNK-
  			String contextPath = "";
@@ -67,10 +64,10 @@ public class IdentifierTableHeaderExtension extends Extension {
  				contextPath += "/" + WebConstants.WEBAPP_NAME;
  			}
  			
- 	 		if (openMRSversionShort.compareTo(new DefaultArtifactVersion("1.7")) < 0) {
+ 	 		if (ModuleUtil.compareVersion(OpenmrsConstants.OPENMRS_VERSION_SHORT, "1.7") < 0) {
  	 			sb.append("<script src=\"" + contextPath + "/moduleResources/idgen/jquery-1.3.2.min.js\" type=\"text/javascript\"></script>\n");
  	 		}
- 	 		if (openMRSversionShort.compareTo(new DefaultArtifactVersion("1.8")) < 0) {
+ 	 		if (ModuleUtil.compareVersion(OpenmrsConstants.OPENMRS_VERSION_SHORT, "1.8") < 0) {
  	 			sb.append("<script src=\"" + contextPath + "/moduleResources/idgen/newPatientFormExtensions.js\" type=\"text/javascript\"></script>\n"); 		
  	 		}
  	 		else {

--- a/pom.xml
+++ b/pom.xml
@@ -81,12 +81,6 @@
             <scope>test</scope>
         </dependency>
         
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-artifact</artifactId>
-            <version>3.0.3</version>
-        </dependency>
-        
 	</dependencies>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,13 @@
             <version>1.9.0</version>
             <scope>test</scope>
         </dependency>
+        
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>3.0.3</version>
+        </dependency>
+        
 	</dependencies>
 
 	<properties>
@@ -295,6 +302,8 @@
 				</plugins>
 			</build>
 		</profile>
+	
+		
 	</profiles>
 
 	<repositories>


### PR DESCRIPTION
The checking of OpenMRS versions did not work with OpenMRS >=1.10
I've implemented version comparing with Maven Artifact.
Here how the results are different from the old comparing (see specilly the comparing with "1.10.1"):

    "1.6.60bd9b".compareTo("1.7") => -1
    new DefaultArtifactVersion("1.6.60bd9b").compareTo(new DefaultArtifactVersion("1.7")) => -1
    "1.6".compareTo("1.7") => -1
    new DefaultArtifactVersion("1.6").compareTo(new DefaultArtifactVersion("1.7")) => -1 
    "1.7.60bd9b".compareTo("1.7") => 7
    new DefaultArtifactVersion("1.7.60bd9b").compareTo(new DefaultArtifactVersion("1.7")) => 1
    "1.7".compareTo("1.7") => 0
    new DefaultArtifactVersion("1.7").compareTo(new DefaultArtifactVersion("1.7")) =>0 			
    "1.9.7.60bd9b".compareTo("1.7")=> 2
    new DefaultArtifactVersion("1.9.7.60bd9b").compareTo(new DefaultArtifactVersion("1.7")) => 1
    "1.9.7".compareTo("1.7") => 2
    new DefaultArtifactVersion("1.9.7").compareTo(new DefaultArtifactVersion("1.7")) => 1
    "1.10.1".compareTo("1.7") => -6
    new DefaultArtifactVersion("1.10.1").compareTo(new DefaultArtifactVersion("1.7")) => 1
    "1.10.1.4ba699 ".compareTo("1.7") => -6
    new DefaultArtifactVersion("1.10.1.4ba699").compareTo(new DefaultArtifactVersion("1.7")) => -1
 	