### PR TITLE
TRUNK-4610: replace deprecated TimerFactoryBean with Spring's suggested ...

### DIFF
--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -82,13 +82,13 @@
 		</property>
 	</bean>
 
-    <bean id="idgenTimerFactory" class="org.springframework.scheduling.timer.TimerFactoryBean">
-        <property name="scheduledTimerTasks">
+    <bean id="idgenTimerFactory" class="org.springframework.scheduling.concurrent.ScheduledExecutorFactoryBean">
+        <property name="scheduledExecutorTasks">
             <list>
-                <bean id="refillIdentifierPools" class="org.springframework.scheduling.timer.ScheduledTimerTask">
+                <bean id="refillIdentifierPools" class="org.springframework.scheduling.concurrent.ScheduledExecutorTask">
                     <property name="delay" value="10000" /> <!-- delay 10 seconds -->
                     <property name="period" value="300000" /> <!-- run every 5 minutes -->
-                    <property name="timerTask">
+                    <property name="runnable">
                         <bean class="org.openmrs.module.idgen.task.RefillIdentifierPoolsTask"/>
                     </property>
                 </bean>

--- a/api/src/test/resources/TestingApplicationContext.xml
+++ b/api/src/test/resources/TestingApplicationContext.xml
@@ -26,13 +26,13 @@
 		<!--  default properties must be set in the hibernate.default.properties -->
 	</bean>
 
-    <bean id="idgenTestTimerFactory" class="org.springframework.scheduling.timer.TimerFactoryBean">
-        <property name="scheduledTimerTasks">
+    <bean id="idgenTestTimerFactory" class="org.springframework.scheduling.concurrent.ScheduledExecutorFactoryBean">
+        <property name="scheduledExecutorTasks">
             <list>
-                <bean id="refillIdentifierPools" class="org.springframework.scheduling.timer.ScheduledTimerTask">
+                <bean id="refillIdentifierPools" class="org.springframework.scheduling.concurrent.ScheduledExecutorTask">
                     <property name="delay" value="5000" />
                     <property name="period" value="5000" />
-                    <property name="timerTask">
+                    <property name="runnable">
                         <bean class="org.openmrs.module.idgen.task.TestTask"/>
                     </property>
                 </bean>


### PR DESCRIPTION
...scheduling.concurrent

Tested that the task fires off successfully in the embedded jetty container, running both openmrs-core Spring 3 (master) and Spring 4 (spring-4 branch). There is also an integration test for the task runner (AuthenticatedTaskIT) which passes.