### PR TITLE
IDGEN-77 Create Log Entry Resource

### DIFF
--- a/omod/src/main/java/org/openmrs/module/idgen/rest/resource/LogEntryResource.java
+++ b/omod/src/main/java/org/openmrs/module/idgen/rest/resource/LogEntryResource.java
@@ -1,0 +1,102 @@
+/* * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.idgen.rest.resource;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import org.openmrs.User;
+import org.openmrs.api.UserService;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.idgen.IdentifierSource;
+import org.openmrs.module.idgen.LogEntry;
+import org.openmrs.module.idgen.service.IdentifierSourceService;
+import org.openmrs.module.idgen.web.controller.IdgenRestController;
+import org.openmrs.module.webservices.rest.web.ConversionUtil;
+import org.openmrs.module.webservices.rest.web.RequestContext;
+import org.openmrs.module.webservices.rest.web.RestConstants;
+import org.openmrs.module.webservices.rest.web.annotation.Resource;
+import org.openmrs.module.webservices.rest.web.representation.Representation;
+import org.openmrs.module.webservices.rest.web.resource.api.PageableResult;
+import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingCrudResource;
+import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
+import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
+import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
+
+@Resource(name = RestConstants.VERSION_1 + IdgenRestController.IDGEN_NAMESPACE
+        + "/viewlogentries", supportedClass = LogEntry.class, supportedOpenmrsVersions = { "1.9.*", "1.10.*", "1.11.*",
+                "1.12.*", "2.0.*", "2.1.*" })
+
+public class LogEntryResource extends DelegatingCrudResource<LogEntry> {
+
+    @Override
+    protected NeedsPaging<LogEntry> doGetAll(RequestContext context) {
+        return new NeedsPaging<LogEntry>(
+                Context.getService(IdentifierSourceService.class).getLogEntries(null, null, null, null, null, null),
+                context);
+    }
+
+    @Override
+    protected PageableResult doSearch(RequestContext context) {
+        IdentifierSourceService identifierSourceService = Context.getService(IdentifierSourceService.class);
+        UserService service = Context.getUserService();
+
+        String source = context.getRequest().getParameter("source");
+        String fromDate = context.getRequest().getParameter("fromDate");
+        String toDate = context.getRequest().getParameter("toDate");
+        String identifier = context.getRequest().getParameter("identifier");
+        String comment = context.getRequest().getParameter("comment");
+        String generatedBy = context.getRequest().getParameter("generatedBy");
+        
+
+        List<LogEntry> logEntries = new ArrayList<LogEntry>();
+
+        IdentifierSource logSource = source != null ? identifierSourceService.getIdentifierSourceByUuid(source) : null;
+        Date dateFrom = fromDate != null ? (Date) ConversionUtil.convert(fromDate, Date.class) : null;
+        Date dateTo = toDate != null ? (Date) ConversionUtil.convert(toDate, Date.class) : null;
+        User user = generatedBy != null ? service.getUserByUuid(generatedBy) : null;
+
+        logEntries = identifierSourceService.getLogEntries(logSource, dateFrom, dateTo, identifier, user, comment);
+        return new NeedsPaging<LogEntry>(logEntries, context);
+    }
+
+    @Override
+    public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
+        return null;
+    }
+
+    @Override
+    public LogEntry newDelegate() throws ResourceDoesNotSupportOperationException {
+        return null;
+
+    }
+
+    @Override
+    public LogEntry save(LogEntry delegate) throws ResourceDoesNotSupportOperationException {
+        return null;
+
+    }
+
+    @Override
+    public LogEntry getByUniqueId(String uniqueId) {
+        return null;
+    }
+
+    @Override
+    protected void delete(LogEntry delegate, String reason, RequestContext context)
+            throws ResourceDoesNotSupportOperationException {
+
+    }
+
+    @Override
+    public void purge(LogEntry delegate, RequestContext context) throws ResourceDoesNotSupportOperationException {
+
+    }
+
+}

--- a/omod/src/main/java/org/openmrs/module/idgen/rest/search/LogEntrySearchHandler.java
+++ b/omod/src/main/java/org/openmrs/module/idgen/rest/search/LogEntrySearchHandler.java
@@ -1,0 +1,79 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.idgen.rest.search;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import org.openmrs.module.idgen.IdentifierSource;
+import org.openmrs.module.idgen.LogEntry;
+import org.openmrs.module.idgen.service.IdentifierSourceService;
+import org.openmrs.module.webservices.rest.web.ConversionUtil;
+import org.openmrs.module.webservices.rest.web.RequestContext;
+import org.openmrs.module.webservices.rest.web.RestConstants;
+import org.openmrs.module.webservices.rest.web.api.RestService;
+import org.openmrs.module.webservices.rest.web.resource.api.PageableResult;
+import org.openmrs.module.webservices.rest.web.resource.api.SearchConfig;
+import org.openmrs.module.webservices.rest.web.resource.api.SearchHandler;
+import org.openmrs.User;
+import org.openmrs.api.UserService;
+import org.openmrs.api.context.Context;
+
+import org.openmrs.module.webservices.rest.web.resource.api.SearchQuery;
+import org.openmrs.module.webservices.rest.web.resource.impl.EmptySearchResult;
+import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
+import org.openmrs.module.webservices.rest.web.response.ResponseException;
+import org.openmrs.util.LocaleUtility;
+import org.openmrs.util.OpenmrsClassLoader;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LogEntrySearchHandler implements SearchHandler {
+
+    private final SearchConfig searchConfig = new SearchConfig("default", RestConstants.VERSION_1 + "/viewlogentries",
+            Arrays.asList("1.8.*", "1.9.*", "1.10.*", "1.11.*", "1.12.*", "2.0.*", "2.1.*"),
+            Arrays.asList(new SearchQuery.Builder(
+                    "Allows you to find log of ID Generation Activities by Source Name, Identifier contents,Generated Date Range,Comment contents and User who generated the log entry")
+                            .withOptionalParameters("source", "identifier", "fromDate", "toDate", "comment",
+                                    "generatedBy")
+                            .build()));
+
+    @Override
+    public PageableResult search(RequestContext context) throws ResponseException {
+        IdentifierSourceService identifierSourceService = Context.getService(IdentifierSourceService.class);
+
+        String source = context.getRequest().getParameter("source");
+        String identifier = context.getRequest().getParameter("identifier");
+        String comment = context.getRequest().getParameter("comment");
+        String generatedBy = context.getRequest().getParameter("generatedBy");
+        String fromDate = context.getRequest().getParameter("fromDate");
+        String toDate = context.getRequest().getParameter("toDate");
+
+        List<LogEntry> logEntries = new ArrayList<LogEntry>();
+
+        IdentifierSource logSource = identifierSourceService.getIdentifierSourceByUuid(source);
+        Date dateFrom = fromDate != null ? (Date) ConversionUtil.convert(fromDate, Date.class) : null;
+        Date dateTo = toDate != null ? (Date) ConversionUtil.convert(toDate, Date.class) : null;
+        UserService service = Context.getUserService();
+        User user = generatedBy != null ? service.getUserByUuid(generatedBy) : null;
+
+        logEntries = identifierSourceService.getLogEntries(logSource, dateFrom, dateTo, identifier, user, comment);
+
+        return new NeedsPaging<LogEntry>(logEntries, context);
+
+    }
+
+    public SearchConfig getSearchConfig() {
+        return searchConfig;
+    }
+
+}

--- a/omod/src/test/java/org/openmrs/module/idgen/web/controller/LogEntryControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/idgen/web/controller/LogEntryControllerTest.java
@@ -1,0 +1,174 @@
+/* * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.idgen.web.controller;
+
+import org.junit.Test;
+import org.junit.Before;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.idgen.service.IdentifierSourceService;
+import org.openmrs.module.webservices.rest.SimpleObject;
+import org.openmrs.module.webservices.rest.test.Util;
+import org.openmrs.module.webservices.rest.web.v1_0.controller.MainResourceControllerTest;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+import org.junit.Assert;
+
+public class LogEntryControllerTest extends MainResourceControllerTest {
+    private static final String LOG_ENTRIES_XML = "logEntriesTestDataset.xml";
+
+    private IdentifierSourceService service;
+
+    @Before
+    public void before() {
+        this.service = Context.getService(IdentifierSourceService.class);
+
+    }
+
+    @Override
+    public long getAllCount() {
+        return service.getLogEntries(null, null, null, null, null, null).size();
+    }
+
+    @Override
+    public String getURI() {
+        return "idgen/viewlogentries";
+    }
+
+    @Override
+    public String getUuid() {
+        return null;
+    }
+
+    @Test
+    public void shouldListAllLogEntries() throws Exception {
+        MockHttpServletRequest req = request(RequestMethod.GET, getURI());
+        SimpleObject result = deserialize(handle(req));
+        Assert.assertNotNull(result);
+        Assert.assertEquals(getAllCount(), Util.getResultsSize(result));
+    }
+
+    @Test
+    public void shouldSearchAndReturnAListOfLogEntriesWithGivenSourceName() throws Exception {
+        executeDataSet(LOG_ENTRIES_XML);
+        MockHttpServletRequest req = request(RequestMethod.GET, getURI());
+        req.addParameter("source", "Generator");
+        SimpleObject result = deserialize(handle(req));
+        Assert.assertNotNull(result);
+        Assert.assertEquals(3, Util.getResultsSize(result));
+    }
+
+    @Test
+    public void shouldSearchAndReturnNothingIfSourceNameDoesNotMatch() throws Exception {
+        executeDataSet(LOG_ENTRIES_XML);
+        MockHttpServletRequest req = request(RequestMethod.GET, getURI());
+        req.addParameter("source", "invalid_source");
+        SimpleObject result = deserialize(handle(req));
+        Assert.assertEquals(0, Util.getResultsSize(result));
+    }
+
+    @Test
+    public void shouldSearchAndReturnAListOfLogEntriesWithIdentifier() throws Exception {
+        executeDataSet(LOG_ENTRIES_XML);
+        MockHttpServletRequest req = request(RequestMethod.GET, getURI());
+        req.addParameter("identifier", "H9");
+        SimpleObject result = deserialize(handle(req));
+        Assert.assertEquals(2, Util.getResultsSize(result));
+    }
+
+    @Test
+    public void shouldSearchAndReturnNothingIfIdentifierDoesNotMatch() throws Exception {
+        executeDataSet(LOG_ENTRIES_XML);
+        MockHttpServletRequest req = request(RequestMethod.GET, getURI());
+        req.addParameter("identifier", "invalid-identifier");
+        SimpleObject result = deserialize(handle(req));
+        Assert.assertEquals(0, Util.getResultsSize(result));
+
+    }
+
+    @Test
+    public void shouldSearchAndReturnAListOfLogEntriesGeneratedInDateRange() throws Exception {
+        executeDataSet(LOG_ENTRIES_XML);
+        MockHttpServletRequest req = request(RequestMethod.GET, getURI());
+        req.addParameter("fromDate", "1/10/2016");
+        req.addParameter("toDate", "30/09/2017");
+        SimpleObject result = deserialize(handle(req));
+        Assert.assertEquals(2, Util.getResultsSize(result));
+    }
+
+    @Test
+    public void shouldSearchAndReturnNothingIfNoLogsGeneratedWithinRange() throws Exception {
+        executeDataSet(LOG_ENTRIES_XML);
+        MockHttpServletRequest req = request(RequestMethod.GET, getURI());
+        req.addParameter("fromDate", "1/10/2015");
+        req.addParameter("toDate", "30/09/2016");
+        SimpleObject result = deserialize(handle(req));
+        Assert.assertEquals(0, Util.getResultsSize(result));
+    }
+
+    @Test
+    public void shouldSearchAndReturnAListOfLogEntriesWhoseCommentsContain() throws Exception {
+        executeDataSet(LOG_ENTRIES_XML);
+        MockHttpServletRequest req = request(RequestMethod.GET, getURI());
+        req.addParameter("comment", "New");
+        SimpleObject result = deserialize(handle(req));
+        Assert.assertEquals(2, Util.getResultsSize(result));
+    }
+
+    @Test
+    public void shouldSearchAndReturnNothingIfCommentsDontContain() throws Exception {
+        executeDataSet(LOG_ENTRIES_XML);
+        MockHttpServletRequest req = request(RequestMethod.GET, getURI());
+        req.addParameter("comment", "invalid comment");
+    }
+
+    @Test
+    public void shouldSearchAndReturnAListOfLogEntriesGeneratedByUser() throws Exception {
+        executeDataSet(LOG_ENTRIES_XML);
+        MockHttpServletRequest req = request(RequestMethod.GET, getURI());
+        req.addParameter("generatedby", "Admin");
+        SimpleObject result = deserialize(handle(req));
+        Assert.assertEquals(4, Util.getResultsSize(result));
+    }
+
+    @Test
+    public void shouldSearchAndReturnAListOfLogEntriesWithMatchingSpecifiedParameters() throws Exception {
+        executeDataSet(LOG_ENTRIES_XML);
+        MockHttpServletRequest req = request(RequestMethod.GET, getURI());
+        req.addParameter("generatedby", "Admin");
+        req.addParameter("identifier", "100");
+        req.addParameter("comment", "New");
+        req.addParameter("fromDate", "1/10/2016");
+        req.addParameter("toDate", "30/09/2017");
+        SimpleObject result = deserialize(handle(req));
+        Assert.assertEquals(4, Util.getResultsSize(result));
+    }
+
+    @Test
+    public void shouldSearchAndReturnNothingIfSelectedUserGeneratedNoLogEntries() throws Exception {
+        executeDataSet(LOG_ENTRIES_XML);
+        MockHttpServletRequest req = request(RequestMethod.GET, getURI());
+        req.addParameter("generatedby", "nologsuser");
+        SimpleObject result = deserialize(handle(req));
+        Assert.assertEquals(0, Util.getResultsSize(result));
+    }
+
+    @Test
+    public void shouldSearchAndReturnNothingIfOneOfTheParametersDoesnotMatch() throws Exception {
+        executeDataSet(LOG_ENTRIES_XML);
+        MockHttpServletRequest req = request(RequestMethod.GET, getURI());
+        req.addParameter("generatedby", "nologsuser");
+        req.addParameter("identifier", "100");
+        req.addParameter("comment", "New");
+        SimpleObject result = deserialize(handle(req));
+        Assert.assertEquals(0, Util.getResultsSize(result));
+
+    }
+
+}

--- a/omod/src/test/resources/logEntriesTestDataset.xml
+++ b/omod/src/test/resources/logEntriesTestDataset.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dataset>
+    <log_entry source="Generator" generatedby="Admin" identifier="100892" comment="New patient " dateGenerated="3/10/2016"/>
+    <log_entry source="Generator" generatedby="Admin" identifier="100HH9" comment="Demo Data " dateGenerated="3/10/2017"/>
+    <log_entry source="Generator" generatedby="Admin" identifier="100H9T" comment=" " dateGenerated="1/10/2017"/>
+    <log_entry source="Clinical Officer" generatedby="Admin" identifier="100H28" comment="New Visit " dateGenerated="2/10/2017"/>
+    <log_entry source="Doctor" generatedby="Admin" identifier="100GYF" comment="" dateGenerated="20/09/2017"/>
+</dataset>


### PR DESCRIPTION
## JIRA TICKET NAME:

[IDGEN-67 View Log Entries RESTFUL API Creation](https://issues.openmrs.org/browse/IDGEN-67)

## SUMMARY:
Create Resource for the Log Entries endpoint that searches through and lists all ID Generation activities on OpenMRS

**_Note:_** _PR only contains [LogEntryResource](https://issues.openmrs.org/browse/IDGEN-77), [LogEntrySearchHandler](https://issues.openmrs.org/browse/IDGEN-68), [LogEntryControllerTest](https://issues.openmrs.org/browse/IDGEN-69) classes_