### PR TITLE
IDGEN-104 Make Breadcrumbs separator uniform with other modules

### DIFF
--- a/owa/app/css/openmrs-owa-idgen.css
+++ b/owa/app/css/openmrs-owa-idgen.css
@@ -188,6 +188,10 @@ li.breadcrumb-item.active {
     font-size: .9em;
 }
 
+li.breadcrumb-item+.breadcrumb-item::before {
+    content: ">"
+}
+
 /*--------------View Logs Tab ------------*/
 .center {
     text-align: center


### PR DESCRIPTION
## JIRA TICKET NAME:

[IDGEN-104 Make Breadcrumbs separator uniform with other modules](https://issues.openmrs.org/browse/IDGEN-104)

## SUMMARY:
Change Separator from a _backward slash_ (**/**) to an _angle bracket_ (**>**)