### PR TITLE
IDGEN-116 Liquibase error on initializing IDGEN module on PostgreSQL

### DIFF
--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -261,7 +261,7 @@
 			<columnExists tableName="idgen_seq_id_gen" columnName="max_length"/>
 			<columnExists tableName="idgen_seq_id_gen" columnName="min_length"/>
 		</preConditions>
-		<sql>UPDATE `idgen_seq_id_gen` SET `max_length` = `min_length`</sql>
+		<sql>UPDATE idgen_seq_id_gen SET max_length = min_length</sql>
 	</changeSet>
 
 	<changeSet id="d5bc38a3-35e3-4a16-b1b2-df6f4c32ec7a" author="Partners In Health">

--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -257,6 +257,8 @@
 	</changeSet>
 
 	<changeSet id="a5b34ba3-2cb0-46b5-bb47-4e07da4a7acd" author="Jeremy Keiper">
+		<validCheckSum>8:87d442ef15920fbbb282a63243b4d241</validCheckSum> <!-- old checksum without removing ` from sql-->
+		<validCheckSum>8:bf30ad2e0f1f88d6f04731aa96ae0367</validCheckSum> <!-- current checksum after removing ` from sql -->
 		<preConditions onFail="MARK_RAN">
 			<columnExists tableName="idgen_seq_id_gen" columnName="max_length"/>
 			<columnExists tableName="idgen_seq_id_gen" columnName="min_length"/>


### PR DESCRIPTION
**Description of Changes I Made :**
In the logs here https://pastebin.com/g6Em5xiT it is seen that error is due to the use of this quote  in query. I have tested the change on both MySQL and PostgreSQL and the change set gets executed without any errors after removing "`" .

**Link to Ticket :** https://issues.openmrs.org/browse/IDGEN-116