### PR TITLE
(chore) O3-3551: Use latest Actions in GH Actions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java-version }}
+          distribution: 'temurin'
       - name: Cache local Maven repository
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
https://openmrs.atlassian.net/browse/O3-3551

Most of our repositories currently use actions/setup-java@v3 for Java setup and actions/checkout@v3 for code checkout within our CI pipelines. However, updated versions, actions/setup-java@v4 and actions/checkout@v4, are now available and should be considered for adoption across our projects.